### PR TITLE
Solr https

### DIFF
--- a/distribution/ddf-common/src/main/resources-filtered/etc/system.properties
+++ b/distribution/ddf-common/src/main/resources-filtered/etc/system.properties
@@ -83,9 +83,9 @@ org.codice.ddf.system.registry-id=
 # For Solr External Provider:
 solr.client=HttpSolrClient
 solr.http.port=8994
-solr.http.url=https://localhost:${solr.http.port}/solr
+solr.http.url=http://localhost:${solr.http.port}/solr
 solr.data.dir=_DO_NOT_EXPAND_${ddf.data}/solr
-solr.managed-by-ddf=true
+solr.managed.internally=true
 
 # For Solr Cloud Provider:
 # solr.client=CloudSolrClient

--- a/distribution/ddf-common/src/main/resources-filtered/etc/system.properties
+++ b/distribution/ddf-common/src/main/resources-filtered/etc/system.properties
@@ -83,8 +83,9 @@ org.codice.ddf.system.registry-id=
 # For Solr External Provider:
 solr.client=HttpSolrClient
 solr.http.port=8994
-solr.http.url=http://localhost:${solr.http.port}/solr
+solr.http.url=https://localhost:${solr.http.port}/solr
 solr.data.dir=_DO_NOT_EXPAND_${ddf.data}/solr
+solr.managed-by-ddf=true
 
 # For Solr Cloud Provider:
 # solr.client=CloudSolrClient

--- a/distribution/ddf-common/src/main/resources/bin/ddf
+++ b/distribution/ddf-common/src/main/resources/bin/ddf
@@ -1,39 +1,36 @@
 #!/bin/sh
 
-
 # Store arguments for use in local functions
 FIRST_ARGUMENT=$1
 ALL_ARGUMENTS=$@
 
-
-# Set useful directories
+# Useful directories
 SCRIPTDIR=$(dirname $0)
 DDF_HOME=$(cd "${SCRIPTDIR}/.."; pwd -P)
 
 # Declare Karaf executable's return code
 KARAF_EXEC_RC=-1
 
-# Set useful files
+# Useful files
 PROPERTIES_FILE=$DDF_HOME/etc/system.properties
 RESTART_FILE="$SCRIPTDIR/restart.jvm"
 SOLR_EXEC=${DDF_HOME}/solr/bin/solr
 
-
 # Extract the value of a property from a Java properties file
 # This function does not handle multi-line properties
 get_property() {
-    grep ^$1 "$PROPERTIES_FILE" | cut -d '=' -f2
+    grep ^$1= "$PROPERTIES_FILE" | cut -d '=' -f2
 }
 
 
 # Extract values from Java properties file and construct Solr URL
-MANAGE_SOLR=$( get_property "solr.managed-by-ddf" )
-SOLR_PORT=$( get_property "solr.http.port" )
-TEMPLATE=$( get_property "solr.http.url" )
+MANAGE_SOLR=$(get_property solr.managed.internally)
+SOLR_PORT=$(get_property solr.http.port)
+TEMPLATE=$(get_property solr.http.url)
 PARTIAL_URL="$(echo $TEMPLATE | sed -e 's/\${solr.http.port}/PORT_PLACEHOLDER/')"
 SOLR_URL=${PARTIAL_URL/"PORT_PLACEHOLDER"/$SOLR_PORT}
 
-
+## TODO: I do not think "daemon" is still a mode. The name might have changed to "server"
 # Return 0 (success/true) if Karaf was started as a daemon
 is_daemon_mode() {
     local RC=1
@@ -43,16 +40,15 @@ is_daemon_mode() {
     return $RC
 }
 
-
 # Return 0 (success/true) if the Solr lifecycle should be managed by this script
 is_managing_solr() {
-    local RC=1;
-    if [ $MANAGE_SOLR == true ]; then
-        RC=0;
-    fi
-    return $RC
+  grep -i true <<< $MANAGE_SOLR > /dev/null
 }
 
+# Return 0 (success/true) if the input parameter is "http" (in any case)
+is_protocol_https() {
+    grep -i ^HTTPS <<< $1 > /dev/null
+}
 
 # Return 0 (success/true) if ddf_on_error.sh created a restart file
 is_restarting() {
@@ -62,7 +58,6 @@ is_restarting() {
     fi
     return $RC
 }
-
 
 # Return 0 (sucess/true) if Solr is up and running
 is_solr_running() {
@@ -76,16 +71,14 @@ is_solr_running() {
     curl -k --silent --connect-timeout $TIMEOUT "$SOLR_URL"/catalog/admin/ping 2>&1 | grep OK > /dev/null
 }
 
-
 # Remove the restart file so we can detect later if restart was requested
 clear_restart_flag() {
   rm -f $RESTART_FILE
 }
 
-
-# Blindly start Solr. Before calling, check if Solr is already running.
+# Blindly start Solr. Before calling this function, check if Solr is already running.
 start_solr() {
-    echo "Starting Solr on port $SOLR_PORT"
+        echo "Solr URL is $SOLR_URL"
         $SOLR_EXEC restart -p $SOLR_PORT
         local SOLR_START_RC=$?
         if [ "$SOLR_START_RC" -ne 0 ]; then
@@ -93,14 +86,24 @@ start_solr() {
         fi
 }
 
+# Set special environment variables used by Solr to configure TLS
+set_solr_https_properties() {
+      export SOLR_SSL_KEY_STORE=$DDF_HOME/$(get_property javax.net.ssl.keyStore)
+      export SOLR_SSL_KEY_STORE_PASSWORD=$(get_property javax.net.ssl.keyStorePassword)
+      export SOLR_SSL_KEY_STORE_TYPE=$(get_property javax.net.ssl.keyStoreType)
+      export SOLR_SSL_TRUST_STORE=$DDF_HOME/$(get_property javax.net.ssl.trustStore)
+      export SOLR_SSL_TRUST_STORE_PASSWORD=$(get_property javax.net.ssl.trustStorePassword)
+      export SOLR_SSL_TRUST_STORE_TYPE=$(get_property javax.net.ssl.trustStoreType)
+      export SOLR_SSL_NEED_CLIENT_AUTH=false
+      export SOLR_SSL_WANT_CLIENT_AUTH=false
+}
 
 stop_solr() {
     $SOLR_EXEC stop -p $SOLR_PORT
 }
 
-
 print_messages() {
-    echo "DDF HOME IS $DDF_HOME"
+    echo "DDF home is $DDF_HOME"
 }
 
 
@@ -109,13 +112,15 @@ start_karaf() {
     ${SCRIPTDIR}/karaf ${ALL_ARGUMENTS}
 }
 
-
 attempt_startup() {
 
     if is_managing_solr; then
         if is_solr_running; then
             echo "Solr is already running. Skipping Solr start."
         else
+            if is_protocol_https $SOLR_URL; then
+                set_solr_https_properties
+            fi
             start_solr;
         fi
     else
@@ -139,7 +144,6 @@ attempt_shutdown() {
 
     echo "Restarting JVM..."
 }
-
 
 while true; do
     clear_restart_flag

--- a/distribution/ddf-common/src/main/resources/bin/ddf
+++ b/distribution/ddf-common/src/main/resources/bin/ddf
@@ -1,55 +1,149 @@
 #!/bin/sh
 
-SCRIPTDIR=$(dirname "$0")
-DDF_HOME=$(cd "${SCRIPTDIR}/.."; pwd -P)
-SOLR_EXEC=${DDF_HOME}/solr/bin/solr
-PROPERTIES_FILE=${DDF_HOME}/etc/system.properties
 
+# Store arguments for use in local functions
+FIRST_ARGUMENT=$1
+ALL_ARGUMENTS=$@
+
+
+# Set useful directories
+SCRIPTDIR=$(dirname $0)
+DDF_HOME=$(cd "${SCRIPTDIR}/.."; pwd -P)
+
+# Declare Karaf executable's return code
+KARAF_EXEC_RC=-1
+
+# Set useful files
+PROPERTIES_FILE=$DDF_HOME/etc/system.properties
+RESTART_FILE="$SCRIPTDIR/restart.jvm"
+SOLR_EXEC=${DDF_HOME}/solr/bin/solr
+
+
+# Extract the value of a property from a Java properties file
 # This function does not handle multi-line properties
 get_property() {
     grep ^$1 "$PROPERTIES_FILE" | cut -d '=' -f2
 }
 
+
+# Extract values from Java properties file and construct Solr URL
+MANAGE_SOLR=$( get_property "solr.managed-by-ddf" )
 SOLR_PORT=$( get_property "solr.http.port" )
+TEMPLATE=$( get_property "solr.http.url" )
+PARTIAL_URL="$(echo $TEMPLATE | sed -e 's/\${solr.http.port}/PORT_PLACEHOLDER/')"
+SOLR_URL=${PARTIAL_URL/"PORT_PLACEHOLDER"/$SOLR_PORT}
+
+
+# Return 0 (success/true) if Karaf was started as a daemon
+is_daemon_mode() {
+    local RC=1
+    if [ "$FIRST_ARGUMENT" = "daemon" ]; then
+       RC=0
+    fi
+    return $RC
+}
+
+
+# Return 0 (success/true) if the Solr lifecycle should be managed by this script
+is_managing_solr() {
+    local RC=1;
+    if [ $MANAGE_SOLR == true ]; then
+        RC=0;
+    fi
+    return $RC
+}
+
+
+# Return 0 (success/true) if ddf_on_error.sh created a restart file
+is_restarting() {
+    local RC=1
+    if [ -f $RESTART_FILE ]; then
+        RC=0
+    fi
+    return $RC
+}
+
+
+# Return 0 (sucess/true) if Solr is up and running
+is_solr_running() {
+
+    # Ping the catalog core and look for the string "OK"
+    # If grep find the string "OK",  command exits with return code 0 (success)
+    # If "OK" is not found, command exists with non-zero return code
+    # FYI: curl prints output to stderr, so direct stderr to stdout before grepping
+    # FYI: Suppress printing to the terminal by redirecting output to dev/null
+    local TIMEOUT=3 #seconds
+    curl -k --silent --connect-timeout $TIMEOUT "$SOLR_URL"/catalog/admin/ping 2>&1 | grep OK > /dev/null
+}
+
+
+# Remove the restart file so we can detect later if restart was requested
+clear_restart_flag() {
+  rm -f $RESTART_FILE
+}
+
+
+# Blindly start Solr. Before calling, check if Solr is already running.
+start_solr() {
+    echo "Starting Solr on port $SOLR_PORT"
+        $SOLR_EXEC restart -p $SOLR_PORT
+        local SOLR_START_RC=$?
+        if [ "$SOLR_START_RC" -ne 0 ]; then
+            echo "WARNING! solr start process returned non-zero error code, please check Solr logs"
+        fi
+}
+
+
+stop_solr() {
+    $SOLR_EXEC stop -p $SOLR_PORT
+}
+
+
+print_messages() {
+    echo "DDF HOME IS $DDF_HOME"
+}
+
+
+start_karaf() {
+    # Arguments to Karaf are optional
+    ${SCRIPTDIR}/karaf ${ALL_ARGUMENTS}
+}
+
+
+attempt_startup() {
+
+    if is_managing_solr; then
+        if is_solr_running; then
+            echo "Solr is already running. Skipping Solr start."
+        else
+            start_solr;
+        fi
+    else
+        echo "Solr is not managed"
+    fi
+
+    # Process suspended while Karaf is running
+    start_karaf
+    KARAF_EXEC_RC=$?
+}
+
+attempt_shutdown() {
+
+    if is_managing_solr && ! is_restarting; then
+        stop_solr
+    fi
+
+    if is_daemon_mode || ! is_restarting; then
+        exit $KARAF_EXEC_RC
+    fi
+
+    echo "Restarting JVM..."
+}
+
 
 while true; do
-  # Remove the restart file indicator so we can detect later if restart was requested
-  rm -f "${SCRIPTDIR}/restart.jvm"
-
-  #Start SOLR
-  #####################################################################################
-  #  ___      _
-  # / __| ___| |_ _
-  # \__ \/ _ \ | '_|
-  # |___/\___/_|_|
-  # TODO (RCZ) Probably need to actually organize this in a smart way.. but for now
-  # probs should do some checks on whether solr is already running and all that jazz
-  # (or if they're doing solr cloud and we don't want to even start this up right now)
-  #####################################################################################
-  echo "Starting Solr on port $SOLR_PORT"
-  echo "Scriptdir is $SCRIPTDIR"
-  echo "DDF_HOME IS $DDF_HOME"
-  $SOLR_EXEC start -p $SOLR_PORT
-  SOLR_START_RC=$?
-  if [ "$SOLR_START_RC" -ne 0 ]; then
-      echo "WARNING! solr start process returned non-zero error code, please check solr logs"
-  fi
-  ####################################################################################
-
-  # Argument to Karaf is optional.
-  # Provides ability to start Karaf in different modes, e.g., server, client, etc.
-  "${SCRIPTDIR}/karaf" "$@"
-  RC=$?
-  if [ "$1" = "daemon" ]; then
-    exit ${RC}
-  else
-    # Check if restart was requested by ddf_on_error.sh
-    if [ -f "${SCRIPTDIR}/restart.jvm" ]; then
-      echo "Restarting JVM..."
-    else
-      echo "Stopping solr process on port $SOLR_PORT"
-      $SOLR_EXEC stop -p $SOLR_PORT
-      exit $RC
-    fi
-  fi
+    clear_restart_flag
+    print_messages
+    attempt_startup
+    attempt_shutdown
 done

--- a/distribution/ddf/pom.xml
+++ b/distribution/ddf/pom.xml
@@ -250,5 +250,12 @@
             <classifier>assembly</classifier>
             <type>zip</type>
         </dependency>
+        <dependency>
+            <groupId>ddf</groupId>
+            <artifactId>solr-distro</artifactId>
+            <version>${project.version}</version>
+            <classifier>assembly</classifier>
+            <type>zip</type>
+        </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
#### What does this PR do?
Allows Solr to used with or without TLS.
To use TLS, edit the solr.http.url property in the system.properties file to begin with "https" instead of "http".

LIMITATIONS: 
1.  Windows ddf.cmd will need to be updated to have similar functionality as the ddf Bash script.
2. One-way TLS currently. Client verification is not turned on.

#### Who is reviewing it? 
@rzwiefel @mcalcote 