### PR TITLE
Ddf solr master itestports memorydocs

### DIFF
--- a/distribution/docs/src/main/resources/content/_installing/installing-intro.adoc
+++ b/distribution/docs/src/main/resources/content/_installing/installing-intro.adoc
@@ -32,7 +32,7 @@ These are the system/environment requirements to configure _prior_ to an install
 
 [NOTE]
 ====
-These requirements assume the Recommended installation profile was used (see <<_setup_types, Setup Types>>) and the use of a remote catalog.
+These requirements assume the recommended installation profile was used (see <<_setup_types, Setup Types>>) and the use of a remote catalog.
 Please consult the https://lucene.apache.org/solr/guide/7_0/solr-system-requirements.html[Solr System Requirements] for guidance if the system will also be hosting a local catalog.
 ====
 

--- a/distribution/docs/src/main/resources/content/_installing/installing-intro.adoc
+++ b/distribution/docs/src/main/resources/content/_installing/installing-intro.adoc
@@ -32,9 +32,8 @@ These are the system/environment requirements to configure _prior_ to an install
 
 [NOTE]
 ====
-These requirements assume the Recommended installation profile was used (see <<_setup_types, Setup Types>>)
-and the use of a remote catalog. Extra resources will need to be allocated if the system will also be
-hosting a local catalog.
+These requirements assume the Recommended installation profile was used (see <<_setup_types, Setup Types>>) and the use of a remote catalog.
+Please consult the https://lucene.apache.org/solr/guide/7_0/solr-system-requirements.html[Solr System Requirements] for guidance if the system will also be hosting a local catalog.
 ====
 
 ======

--- a/distribution/test/itests/README.md
+++ b/distribution/test/itests/README.md
@@ -22,8 +22,8 @@ Solr runs in its own OS process separate PAX-EXAM and the application. Things to
 * The default port for Solr is hardcoded to `9994`. 
 * The Solr administration UI is available at `http://localhost:9994/solr`
 * The Maven exec-maven-plugin executes the Solr start command before the itests begin. The plugin also executes the Solr stop command when the itests have terminated.
-* The files for the Solr instance are located inside of the `test-itest-ddf/target/solr` folder and **not** in the exam folder. Because there is not a per-exam-folder instance of Solr, it is not
- recommended to run multiple itests concurrently because the tests may corrupt each other's data.
+* The files for the Solr instance are located inside of the `test-itest-ddf/target/solr` folder and **not** in the exam folder. There is not a per exam-folder copy of Solr. Therefore it is not
+ recommended to run itests concurrently because the tests may corrupt each other's data.
 * Because not every itest cleans up after itself, it is possible to leak data between separate runs of the itests, **if** the test process terminated abnormally. In such cases, use `mvn clean` to delete the target folder. This ensures future itests have a clean Solr installation.
 
 ## SSH Into a Running Instance

--- a/distribution/test/itests/README.md
+++ b/distribution/test/itests/README.md
@@ -16,12 +16,15 @@ In short:
 * Use remote debugging to debug tests themselves or anything related to production code
 * Use local debugging to debug the code that sets up and configures the testing environment
 
-## Notes on Solr
-Solr is now runs in a separate (3rd) JVM as its own process. The default port is hardcoded to `9994`. (`http://localhost:9994/solr` to access solr UI) Also the actual solr instance lives inside of the `test-itest-ddf/target/solr` folder and **not** in the exam folder. Since there is not a per-exam-folder instance of solr we do not currently support running multiple itests at once. 
+## Solr
+Solr runs in its own OS process separate PAX-EXAM and the application. Things to know include:
 
-The Maven plugin exec-maven-plugin executes the Solr start command before the itests begin. The plugin also executes the Solr stop command when the itests have terminated.
-
-Because not every itest cleans up after itself, it is _possible_ to leak data between separate runs of the itests, if the process was terminated abnormally. Use `mvn clean` to delete the target folder. This ensures future itests have a clean Solr installation.
+* The default port for Solr is hardcoded to `9994`. 
+* The Solr administration UI is available at `http://localhost:9994/solr`
+* The Maven exec-maven-plugin executes the Solr start command before the itests begin. The plugin also executes the Solr stop command when the itests have terminated.
+* The files for the Solr instance are located inside of the `test-itest-ddf/target/solr` folder and **not** in the exam folder. Because there is not a per-exam-folder instance of Solr, it is not
+ recommended to run multiple itests concurrently because the tests may corrupt each other's data.
+* Because not every itest cleans up after itself, it is possible to leak data between separate runs of the itests, **if** the test process terminated abnormally. In such cases, use `mvn clean` to delete the target folder. This ensures future itests have a clean Solr installation.
 
 ## SSH Into a Running Instance
 It is possible to SSH into a running test instance. This will allow you to use the shell to inspect the runtime state while the test probe is installed and running. The SSH port is dynamic and can be found in `target/exam/<GUID>/etc/org.apache.karaf.shell.cfg`.

--- a/distribution/test/itests/test-itests-common/src/main/java/org/codice/ddf/itests/common/AbstractIntegrationTest.java
+++ b/distribution/test/itests/test-itests-common/src/main/java/org/codice/ddf/itests/common/AbstractIntegrationTest.java
@@ -693,7 +693,7 @@ public abstract class AbstractIntegrationTest {
     return options(
         editConfigurationFilePut(SYSTEM_PROPERTIES_REL_PATH, "solr.client", "HttpSolrClient"),
         editConfigurationFilePut(
-            SYSTEM_PROPERTIES_REL_PATH, "solr.http.url", "http://localhost:8994/solr"),
+            SYSTEM_PROPERTIES_REL_PATH, "solr.http.url", "http://localhost:9994/solr"),
         editConfigurationFilePut(
             SYSTEM_PROPERTIES_REL_PATH, "solr.data.dir", "${karaf.home}/data/solr"),
         editConfigurationFilePut(SYSTEM_PROPERTIES_REL_PATH, "solr.cloud.zookeeper", ""));

--- a/distribution/test/itests/test-itests-ddf/pom.xml
+++ b/distribution/test/itests/test-itests-ddf/pom.xml
@@ -310,27 +310,6 @@
 
     <build>
         <plugins>
-            <!--Load system properties to discover the port that DDF expects for Solr-->
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>properties-maven-plugin</artifactId>
-                <version>1.0.0</version>
-                <executions>
-                    <execution>
-                        <phase>initialize</phase>
-                        <goals>
-                            <goal>read-project-properties</goal>
-                        </goals>
-                        <configuration>
-                            <files>
-                                <file>
-                                    ${highest-basedir}/distribution/ddf-common/src/main/resources-filtered/etc/system.properties
-                                </file>
-                            </files>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
 
             <!--Unpack Solr distribution-->
             <plugin>
@@ -379,13 +358,13 @@
                             <executable>${solr.exec}${script.extension}</executable>
                             <arguments>
                                 <!--Restart to stop Solr is already running and the start it.-->
-                                <argument>restart</argument>
+                                <argument>start</argument>
                                 <argument>-p</argument>
                                 <!--The maven properties plugin reads the system properties file-->
                                 <!--and provides the solr.http.port property from it.-->
-                                <argument>${solr.http.port}</argument>
+                                <argument>9994</argument>
                                 <argument>-m</argument>
-                                <argument>2g</argument>
+                                <argument>512m</argument>
                             </arguments>
                             <async>true</async>
                             <asyncDestroyOnShutdown>true</asyncDestroyOnShutdown>
@@ -402,7 +381,7 @@
                             <arguments>
                                 <argument>stop</argument>
                                 <argument>-p</argument>
-                                <argument>${solr.http.port}</argument>
+                                <argument>9994</argument>
                             </arguments>
                             <async>true</async>
                             <asyncDestroyOnShutdown>true</asyncDestroyOnShutdown>


### PR DESCRIPTION
### PR split into two commits for your reviewing pleasure
--------

#### What does this PR do?
 - Changes solr process ports in itests to hardcoded test port so it doesn't conflict with a running ddf process
- Adds documentation for solr memory settings (thanks to @mcalcote )

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
