### PR TITLE
Deprecate Solr Proxy and Embedded Solr

### DIFF
--- a/platform/solr/solr-factory/src/main/java/org/codice/solr/factory/impl/ConfigurationFileProxy.java
+++ b/platform/solr/solr-factory/src/main/java/org/codice/solr/factory/impl/ConfigurationFileProxy.java
@@ -34,6 +34,7 @@ import org.slf4j.LoggerFactory;
  * Abstraction layer for accessing files or directories on disk. Provides different implementations
  * depending on if the code is run within an OSGi container or not.
  */
+@Deprecated
 public class ConfigurationFileProxy {
   public static final String DEFAULT_SOLR_CONFIG_PARENT_DIR = "etc";
 

--- a/platform/solr/solr-factory/src/main/java/org/codice/solr/factory/impl/EmbeddedSolrFiles.java
+++ b/platform/solr/solr-factory/src/main/java/org/codice/solr/factory/impl/EmbeddedSolrFiles.java
@@ -39,6 +39,7 @@ import org.xml.sax.SAXException;
  * <p><i>Note:</i> The corresponding {@link SolrConfig} and {@link IndexSchema} will be constructed
  * the first time they are retrieved.
  */
+@Deprecated
 class EmbeddedSolrFiles {
   private static final Logger LOGGER = LoggerFactory.getLogger(EmbeddedSolrFiles.class);
 


### PR DESCRIPTION
Added deprecated annotations to ConfigurationFileProxy and
EmbeddedSolrFiles to account for deprecation of their usage
based on solr.data.dir

@ahoffer 
@mcalcote 