### PR TITLE
Remove search-ui from starting up in installer

### DIFF
--- a/catalog/ui/search-ui-app/src/main/resources/features.xml
+++ b/catalog/ui/search-ui-app/src/main/resources/features.xml
@@ -52,7 +52,6 @@
         <feature>catalog-versioning-plugin</feature>
         <feature>catalog-core-validator</feature>
         <feature>catalog-ui</feature>
-        <feature>search-ui</feature>
         <feature>simple-search-ui</feature>
     </feature>
 


### PR DESCRIPTION
#### What does this PR do?
removes search-ui from the startup when going through the installer to decrease start up time
#### Who is reviewing it? 
(please choose AT LEAST two reviewers that need to approve the PR before it can get merged)
@ahoffer 
@tbatie 
@garrettfreibott 
